### PR TITLE
Fix trivial problems reported by SpotBugs

### DIFF
--- a/src/main/java/saps/common/core/model/SapsImage.java
+++ b/src/main/java/saps/common/core/model/SapsImage.java
@@ -3,8 +3,9 @@ package saps.common.core.model;
 
 import java.io.Serializable;
 import java.sql.Timestamp;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.Date;
 import org.json.JSONException;
@@ -14,7 +15,7 @@ import saps.common.core.model.enums.ImageTaskState;
 public class SapsImage implements Serializable {
 
   private static final long serialVersionUID = 1L;
-  private static final DateFormat DATE_FORMATER = new SimpleDateFormat("yyyy-MM-dd");
+  private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
   public static final String NONE_FEDERATION_MEMBER = "None";
   public static final String NONE_ARREBOL_JOB_ID = "-1";
@@ -250,6 +251,10 @@ public class SapsImage implements Serializable {
     return dataset + "_" + cal.get(Calendar.DAY_OF_YEAR) + "_" + cal.get(Calendar.YEAR);
   }
 
+  private ZonedDateTime getZonedImageDate() {
+    return imageDate.toInstant().atZone(ZoneId.systemDefault());
+  }
+
   public JSONObject toJSON() throws JSONException {
     JSONObject json = new JSONObject();
 
@@ -258,7 +263,7 @@ public class SapsImage implements Serializable {
     json.put("collectionTierName", getCollectionTierName());
     json.put("dataset", dataset);
     json.put("region", region);
-    json.put("imageDate", DATE_FORMATER.format(imageDate));
+    json.put("imageDate", getZonedImageDate().format(DATE_FORMATTER));
     json.put("state", state.getValue());
     json.put("federationMember", federationMember);
     json.put("priority", priority);
@@ -284,7 +289,7 @@ public class SapsImage implements Serializable {
         + "', region='"
         + region
         + "', imageDate="
-        + DATE_FORMATER.format(imageDate)
+        + getZonedImageDate().format(DATE_FORMATTER)
         + ", state='"
         + state
         + ", federationMember='"

--- a/src/main/java/saps/common/core/model/SapsTask.java
+++ b/src/main/java/saps/common/core/model/SapsTask.java
@@ -2,6 +2,7 @@
 package saps.common.core.model;
 
 import java.io.File;
+import java.io.Serializable;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.HashMap;
@@ -14,7 +15,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-public class SapsTask {
+public class SapsTask implements Serializable {
 
   private static final Logger LOGGER = Logger.getLogger(SapsTask.class);
 

--- a/src/main/java/saps/common/core/model/SapsUser.java
+++ b/src/main/java/saps/common/core/model/SapsUser.java
@@ -1,6 +1,8 @@
 /* (C)2020 */
 package saps.common.core.model;
 
+import java.util.Objects;
+
 public class SapsUser {
 
   private String userEmail;
@@ -73,7 +75,7 @@ public class SapsUser {
 
   @Override
   public boolean equals(Object o) {
-    if (o instanceof SapsImage) {
+    if (o instanceof SapsUser) {
       SapsUser other = (SapsUser) o;
       return getUserEmail().equals(other.getUserEmail())
           && getUserName().equals(other.getUserName())
@@ -83,5 +85,16 @@ public class SapsUser {
           && getAdminRole() == other.getAdminRole();
     }
     return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        getUserEmail(),
+        getUserName(),
+        getUserPassword(),
+        isEnable(),
+        getUserNotify(),
+        getAdminRole());
   }
 }

--- a/src/main/java/saps/common/core/storage/AccessLink.java
+++ b/src/main/java/saps/common/core/storage/AccessLink.java
@@ -39,4 +39,9 @@ public class AccessLink {
     AccessLink that = (AccessLink) o;
     return Objects.equals(name, that.name) && Objects.equals(url, that.url);
   }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, url);
+  }
 }

--- a/src/main/java/saps/common/core/util/ProcessUtil.java
+++ b/src/main/java/saps/common/core/util/ProcessUtil.java
@@ -9,28 +9,30 @@ import java.io.InputStreamReader;
 public class ProcessUtil {
 
   public static String getOutput(Process p) throws IOException {
-    BufferedReader r = new BufferedReader(new InputStreamReader(p.getInputStream()));
-    String out = new String();
-    while (true) {
-      String line = r.readLine();
-      if (line == null) {
-        break;
+    try (BufferedReader r = new BufferedReader(new InputStreamReader(p.getInputStream()))) {
+      StringBuilder out = new StringBuilder();
+      while (true) {
+        String line = r.readLine();
+        if (line == null) {
+          break;
+        }
+        out.append(line);
       }
-      out += line;
+      return out.toString();
     }
-    return out;
   }
 
   public static String getError(Process p) throws IOException {
-    BufferedReader r = new BufferedReader(new InputStreamReader(p.getErrorStream()));
-    String error = new String();
-    while (true) {
-      String line = r.readLine();
-      if (line == null) {
-        break;
+    try (BufferedReader r = new BufferedReader(new InputStreamReader(p.getErrorStream()))) {
+      StringBuilder error = new StringBuilder();
+      while (true) {
+        String line = r.readLine();
+        if (line == null) {
+          break;
+        }
+        error.append(line);
       }
-      error += line;
+      return error.toString();
     }
-    return error;
   }
 }

--- a/src/test/java/saps/common/core/storage/swift/KeystoneV3IdentityPluginTest.java
+++ b/src/test/java/saps/common/core/storage/swift/KeystoneV3IdentityPluginTest.java
@@ -18,17 +18,20 @@ public class KeystoneV3IdentityPluginTest {
   @Ignore
   public void createToken() throws Exception {
     Properties properties = new Properties();
-    FileInputStream input = new FileInputStream(CONFIG_FILE_PATH);
-    properties.load(input);
 
-    String url = properties.getProperty(SapsPropertiesConstants.Openstack.IdentityService.API_URL);
-    String projectId = properties.getProperty(SapsPropertiesConstants.Openstack.PROJECT_ID);
-    String userId = properties.getProperty(SapsPropertiesConstants.Openstack.USER_ID);
-    String password = properties.getProperty(SapsPropertiesConstants.Openstack.USER_PASSWORD);
+    try (FileInputStream input = new FileInputStream(CONFIG_FILE_PATH)) {
+      properties.load(input);
 
-    IdentityToken token =
-        KeystoneV3IdentityRequestHelper.createIdentityToken(url, projectId, userId, password);
-    assertToken(token);
+      String url =
+          properties.getProperty(SapsPropertiesConstants.Openstack.IdentityService.API_URL);
+      String projectId = properties.getProperty(SapsPropertiesConstants.Openstack.PROJECT_ID);
+      String userId = properties.getProperty(SapsPropertiesConstants.Openstack.USER_ID);
+      String password = properties.getProperty(SapsPropertiesConstants.Openstack.USER_PASSWORD);
+
+      IdentityToken token =
+          KeystoneV3IdentityRequestHelper.createIdentityToken(url, projectId, userId, password);
+      assertToken(token);
+    }
   }
 
   private void assertToken(IdentityToken token) {

--- a/src/test/java/saps/common/core/storage/swift/SwiftAPIClientTest.java
+++ b/src/test/java/saps/common/core/storage/swift/SwiftAPIClientTest.java
@@ -16,9 +16,10 @@ public class SwiftAPIClientTest {
 
   private Properties loadConfigFile(String path) throws IOException {
     Properties properties = new Properties();
-    FileInputStream input = new FileInputStream(path);
-    properties.load(input);
-    return properties;
+    try (FileInputStream input = new FileInputStream(path)) {
+      properties.load(input);
+      return properties;
+    }
   }
 
   @Test

--- a/src/test/java/saps/common/core/storage/swift/SwiftPermanentStorageTest.java
+++ b/src/test/java/saps/common/core/storage/swift/SwiftPermanentStorageTest.java
@@ -188,30 +188,34 @@ public class SwiftPermanentStorageTest {
 
   private Properties createDefaultPropertiesWithoutArchiverInDebugMode() throws IOException {
     Properties properties = new Properties();
-    FileInputStream input = new FileInputStream(ArchiverConfigFilePath.Success.NORMAL_MODE);
-    properties.load(input);
-    return properties;
+    try (FileInputStream input = new FileInputStream(ArchiverConfigFilePath.Success.NORMAL_MODE)) {
+      properties.load(input);
+      return properties;
+    }
   }
 
   private Properties createFailurePropertiesWithoutArchiverInDebugMode() throws IOException {
     Properties properties = new Properties();
-    FileInputStream input = new FileInputStream(ArchiverConfigFilePath.Fail.NORMAL_MODE);
-    properties.load(input);
-    return properties;
+    try (FileInputStream input = new FileInputStream(ArchiverConfigFilePath.Fail.NORMAL_MODE)) {
+      properties.load(input);
+      return properties;
+    }
   }
 
   private Properties createDefaultPropertiesWithArchiverInDebugMode() throws IOException {
     Properties properties = new Properties();
-    FileInputStream input = new FileInputStream(ArchiverConfigFilePath.Success.DEBUG_MODE);
-    properties.load(input);
-    return properties;
+    try (FileInputStream input = new FileInputStream(ArchiverConfigFilePath.Success.DEBUG_MODE)) {
+      properties.load(input);
+      return properties;
+    }
   }
 
   private Properties createFailurePropertiesWithArchiverInDebugMode() throws IOException {
     Properties properties = new Properties();
-    FileInputStream input = new FileInputStream(ArchiverConfigFilePath.Fail.DEBUG_MODE);
-    properties.load(input);
-    return properties;
+    try (FileInputStream input = new FileInputStream(ArchiverConfigFilePath.Fail.DEBUG_MODE)) {
+      properties.load(input);
+      return properties;
+    }
   }
 
   @Test(expected = InvalidPropertyException.class)


### PR DESCRIPTION
Fixed problems reported by SpotBugs that don't change signatures and seems to change no functionality.

+ [x] Upgrade `java.text.DateFormat` to `java.time.*` in possible multi-threaded code.
+ [x] Fix `Serializable` class with non-`Serializable` members
+ [x] Fix `instanceof` comparing to wrong class
+ [x] Enhance performance with String manipulation
+ [x] Fix resources not closed
+ [x] Fix objects with custom `equals` implementation relying on default `hashcode`

The report was generated with the command `mvn com.github.spotbugs:spotbugs-maven-plugin:4.2.3:check`